### PR TITLE
Add Checks for Glyph Name

### DIFF
--- a/GlyphConstruction.roboFontExt/lib/glyphConstruction.py
+++ b/GlyphConstruction.roboFontExt/lib/glyphConstruction.py
@@ -237,14 +237,16 @@ class ConstructionGlyph(object):
 
     def draw(self, pen):
         for glyphName, transformation in self.components:
-            if glyphName in self.glyphset:
-                if self._shouldDecompose:
+            if self._shouldDecompose:
+                try:
                     glyph = self.glyphset[glyphName]
-                    tPen = TransformPen(pen, transformation)
-                    glyph.draw(tPen)
+                except KeyError:
+                    continue
+                tPen = TransformPen(pen, transformation)
+                glyph.draw(tPen)
 
-                else:
-                    pen.addComponent(glyphName, transformation)
+            else:
+                pen.addComponent(glyphName, transformation)
 
     def drawPoints(self, pointPen):
         pen = SegmentToPointPen(pointPen)

--- a/GlyphConstruction.roboFontExt/lib/glyphConstruction.py
+++ b/GlyphConstruction.roboFontExt/lib/glyphConstruction.py
@@ -164,7 +164,8 @@ class ConstructionGlyph(object):
         return self.glyphset
 
     def addComponent(self, glyphName, transformation):
-        self.components.append((glyphName, transformation))
+        if glyphName:
+            self.components.append((glyphName, transformation))
 
     def __len__(self):
         return 0
@@ -236,16 +237,14 @@ class ConstructionGlyph(object):
 
     def draw(self, pen):
         for glyphName, transformation in self.components:
-            if self._shouldDecompose:
-                try:
+            if glyphName in self.glyphset:
+                if self._shouldDecompose:
                     glyph = self.glyphset[glyphName]
-                except KeyError:
-                    continue
-                tPen = TransformPen(pen, transformation)
-                glyph.draw(tPen)
+                    tPen = TransformPen(pen, transformation)
+                    glyph.draw(tPen)
 
-            else:
-                pen.addComponent(glyphName, transformation)
+                else:
+                    pen.addComponent(glyphName, transformation)
 
     def drawPoints(self, pointPen):
         pen = SegmentToPointPen(pointPen)

--- a/Lib/glyphConstruction.py
+++ b/Lib/glyphConstruction.py
@@ -237,14 +237,16 @@ class ConstructionGlyph(object):
 
     def draw(self, pen):
         for glyphName, transformation in self.components:
-            if glyphName in self.glyphset:
-                if self._shouldDecompose:
+            if self._shouldDecompose:
+                try:
                     glyph = self.glyphset[glyphName]
-                    tPen = TransformPen(pen, transformation)
-                    glyph.draw(tPen)
+                except KeyError:
+                    continue
+                tPen = TransformPen(pen, transformation)
+                glyph.draw(tPen)
 
-                else:
-                    pen.addComponent(glyphName, transformation)
+            else:
+                pen.addComponent(glyphName, transformation)
 
     def drawPoints(self, pointPen):
         pen = SegmentToPointPen(pointPen)

--- a/Lib/glyphConstruction.py
+++ b/Lib/glyphConstruction.py
@@ -164,7 +164,8 @@ class ConstructionGlyph(object):
         return self.glyphset
 
     def addComponent(self, glyphName, transformation):
-        self.components.append((glyphName, transformation))
+        if glyphName:
+            self.components.append((glyphName, transformation))
 
     def __len__(self):
         return 0
@@ -236,16 +237,14 @@ class ConstructionGlyph(object):
 
     def draw(self, pen):
         for glyphName, transformation in self.components:
-            if self._shouldDecompose:
-                try:
+            if glyphName in self.glyphset:
+                if self._shouldDecompose:
                     glyph = self.glyphset[glyphName]
-                except KeyError:
-                    continue
-                tPen = TransformPen(pen, transformation)
-                glyph.draw(tPen)
+                    tPen = TransformPen(pen, transformation)
+                    glyph.draw(tPen)
 
-            else:
-                pen.addComponent(glyphName, transformation)
+                else:
+                    pen.addComponent(glyphName, transformation)
 
     def drawPoints(self, pointPen):
         pen = SegmentToPointPen(pointPen)


### PR DESCRIPTION
I was noticing that a glyph construction string like so: `space = ^ 300` would result in a `space` glyph with the correct width, but would also contain a corrupt component with a baseGlyph of `''`. 

I also noticed that the test line 1354 in `glyphConstruction.py` was passing, even though `anotherGlyph` was not a glyph in the dummy font. This construction would also result in a "corrupt" component, right?

```    
>>> result = GlyphConstructionBuilder("agrave = a + grave + anotherGlyph", font)
```

So this PR adds some checks to make sure `glyphName` in various functions, when adding a component, is not None/Falsey and is in the `self.glyphSet`. 

This PR also makes the test on line 1354 fail, because it does not allow `anotherGlyph` to be placed (which I think is the correct behavior, but is open to interpretation): 

```
$ python3 /Users/ford/git/GlyphConstruction/Lib/glyphConstruction.py 
**********************************************************************
File "/Users/ford/git/GlyphConstruction/Lib/glyphConstruction.py", line 1355, in __main__.testGlyphConstructionBuilder_Marks
Failed example:
    testDigestGlyph(result)
Expected:
    ('agrave', 60, None, None, '', (('a', (1, 0, 0, 1, 0, 0), None), ('grave', (1, 0, 0, 1, 0, 0), None), ('anotherGlyph', (1, 0, 0, 1, 0, 0), None)))
Got:
    ('agrave', 60, None, None, '', (('a', (1, 0, 0, 1, 0, 0), None), ('grave', (1, 0, 0, 1, 0, 0), None)))
**********************************************************************
1 items had failures:
   1 of   7 in __main__.testGlyphConstructionBuilder_Marks
***Test Failed*** 1 failures.
```